### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,10 +42,10 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-      run: twine upload --repository testpypi dist/*
+      run: twine upload --repository testpypi dist/cpp_linter_hooks*
     - name: Publish package (to PyPI)
       if: github.event_name != 'workflow_dispatch' && github.repository == 'cpp-linter/cpp-linter-hooks'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+      run: twine upload dist/cpp_linter_hooks*


### PR DESCRIPTION
Fix failure https://github.com/cpp-linter/cpp-linter-hooks/actions/runs/5169624820/jobs/9311989289

```bash
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Invalid API Token: project-scoped token is not valid for project:      
         'clang-tools', project-scoped token is not valid for project:          
         'clang-tools'                                                          
Error: Process completed with exit code 1.
```