### PR TITLE
chore: remove Python 3.8 support as it is EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.14.0-alpha.2", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+        python-version: ["3.14.0-alpha.2", "3.13", "3.12", "3.11", "3.10", "3.9"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=45", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project]
 name = "cpp_linter_hooks"
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Remove Python 3.8 support as it is EOL. btw, pre-commit also does not support Python 3.8 anymore.

https://github.com/pre-commit/pre-commit/blob/aa48766b888990e7b118d12cf757109d96e65a7e/setup.cfg#L27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These updates adjust the automated testing and compatibility settings to align with current Python standards, ensuring a modern and consistent development workflow.

- **Tests**
  - Refined automated testing to focus on supported Python versions for improved validation.
- **Chores**
  - Updated project compatibility to require a minimum Python version of 3.9, dropping older version support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->