### PR TITLE
Update pyproject.toml to adopt PEP639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "cpp_linter_hooks"
 description = "Automatically check c/c++ code with clang-format and clang-tidy"
 readme = "README.md"
 keywords = ["clang", "clang-format", "clang-tidy", "pre-commit", "pre-commit-hooks"]
-license = {text = "MIT License"}
+license = "MIT"
 authors = [
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the license declaration to a more concise, clear format by presenting it directly as "MIT". This change improves the readability and transparency of licensing information without affecting the actual terms, ensuring users have an easier way to verify the license status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->