### PR TITLE
chore: update default clang version to 16

### DIFF
--- a/cpp_linter_hooks/util.py
+++ b/cpp_linter_hooks/util.py
@@ -10,7 +10,7 @@ from clang_tools.install import is_installed as _is_installed, install_tool
 LOG = logging.getLogger(__name__)
 
 
-DEFAULT_CLANG_VERSION = "13"
+DEFAULT_CLANG_VERSION = "16"
 
 
 def is_installed(tool_name: str, version: str) -> Optional[Path]:


### PR DESCRIPTION
closes #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default Clang version used by the tool from 13 to 16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->