### PR TITLE
docs: bump version to v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use cpp-linter-hooks, add the following configuration to your `.pre-commit-co
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v0.6.1  # Use the ref you want to point at
+    rev: v0.8.1  # Use the ref you want to point at
     hooks:
       - id: clang-format
         args: [--style=Google] # Other coding style: LLVM, GNU, Chromium, Microsoft, Mozilla, WebKit.
@@ -36,7 +36,7 @@ To use custom configurations like `.clang-format` and `.clang-tidy`:
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v0.6.1
+    rev: v0.8.1
     hooks:
       - id: clang-format
         args: [--style=file]  # to load .clang-format
@@ -49,7 +49,7 @@ To use specific versions of [clang-tools](https://github.com/cpp-linter/clang-to
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v0.6.1
+    rev: v0.8.1
     hooks:
       - id: clang-format
         args: [--style=file, --version=16] # Specifies version
@@ -63,7 +63,7 @@ repos:
 
 ```yaml
 - repo: https://github.com/cpp-linter/cpp-linter-hooks
-  rev: v0.6.1
+  rev: v0.8.1
   hooks:
   -   id: clang-format
       args: [--style=file, --version=16]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples to reference the latest pre-commit hook version (`v0.8.1`) in all configuration snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->