### PR TITLE
chore: bump clang-tools default version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ repos:
     rev: v0.8.1
     hooks:
       - id: clang-format
-        args: [--style=file, --version=16] # Specifies version
+        args: [--style=file, --version=18] # Specifies version
       - id: clang-tidy
-        args: [--checks=.clang-tidy, --version=16]  # Specifies version
+        args: [--checks=.clang-tidy, --version=18]  # Specifies version
 ```
 
 > [!IMPORTANT]
@@ -66,10 +66,10 @@ repos:
   rev: v0.8.1
   hooks:
   -   id: clang-format
-      args: [--style=file, --version=16]
+      args: [--style=file, --version=18]
       files: ^(src|include)/.*\.(cpp|cc|cxx|h|hpp)$ # limit the scope
   -   id: clang-tidy
-      args: [--checks=.clang-tidy, --version=16]
+      args: [--checks=.clang-tidy, --version=18]
       files: ^(src|include)/.*\.(cpp|cc|cxx|h|hpp)$
 ```
 

--- a/cpp_linter_hooks/util.py
+++ b/cpp_linter_hooks/util.py
@@ -10,7 +10,7 @@ from clang_tools.install import is_installed as _is_installed, install_tool
 LOG = logging.getLogger(__name__)
 
 
-DEFAULT_CLANG_VERSION = "16"
+DEFAULT_CLANG_VERSION = "18"  # Default version for clang tools, can be overridden
 
 
 def is_installed(tool_name: str, version: str) -> Optional[Path]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -6,7 +6,7 @@ from itertools import product
 from cpp_linter_hooks.util import ensure_installed, DEFAULT_CLANG_VERSION
 
 
-VERSIONS = [None, "16"]
+VERSIONS = [None, "18"]
 TOOLS = ["clang-format", "clang-tidy"]
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reference version 18 of clang-format and clang-tidy in configuration examples.

* **Chores**
  * Changed the default clang tool version from 16 to 18.
  * Updated tests to use version 18 instead of 16 for clang tool validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->