### PR TITLE
docs: Upgrade clang-format and clang-tidy to version 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ repos:
     rev: v1.1.0
     hooks:
       - id: clang-format
-        args: [--style=file, --version=18] # Specifies version
+        args: [--style=file, --version=21] # Specifies version
       - id: clang-tidy
-        args: [--checks=.clang-tidy, --version=18] # Specifies version
+        args: [--checks=.clang-tidy, --version=21] # Specifies version
 ```
 
 > [!NOTE]
@@ -180,7 +180,7 @@ repos:
     rev: v1.1.0
     hooks:
       - id: clang-format
-        args: [--style=file, --version=18, --verbose]   # Add -v or --verbose for detailed output
+        args: [--style=file, --version=21, --verbose]   # Add -v or --verbose for detailed output
 ```
 
 ## FAQ


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples to use Clang tool version 21 for clang-format and clang-tidy.
  * Revised the “Custom Clang Tool Version” section and the “Verbose Output” example (clang-format with --verbose).
  * Examples and text only; no code changes.
  * No functional or API changes; build and runtime behavior unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->