### PR TITLE
feat: official support python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uses stable Python releases only, improving consistency and predictability of builds.
* **Tests**
  * Test runs avoid prerelease Python versions, reducing flakiness and unexpected failures.
* **Documentation**
  * No user-facing changes; this update affects internal build and test infrastructure to ensure more stable development and release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->