### PR TITLE
fix: update pyproject.toml dependency to add pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
+    "pip>=20.3", # Required to install clang-format and clang-tidy
     "tomli>=1.1.0; python_version < '3.11'",
     "setuptools>=45.0.0", # Required for pkg_resources in clang-tidy
     "clang-format==21.1.2",


### PR DESCRIPTION
Fix potential issue https://github.com/cpp-linter/cpp-linter-action/issues/364#issuecomment-3460480496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to require pip >= 20.3 (added a clarifying inline comment).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->