### PR TITLE
fix: remove .github/release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,0 @@
-# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
-_extends: .github


### PR DESCRIPTION
```bash
Run release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3
Parsing inputs and configuration...
Error: Unsupported file extension: .github. Supported extensions are: json, yml, yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to modify Release Drafter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->