### PR TITLE
chore(dev): update release-drafter usage

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,0 @@
-# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
-_extends: .github:release-drafter.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,10 +1,15 @@
-name: PR Autolabeler
+name: PR Auto-labeler
 
 on:
-  # pull_request event is required for autolabeler
+  # pull_request event is required for auto-labeler
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions: {}
+
 jobs:
   draft-release:
-    uses: cpp-linter/.github/.github/workflows/release-drafter.yml@main
+    permissions:
+      pull-requests: write
+      contents: read
+    uses: cpp-linter/.github/.github/workflows/pr-labeler.yml@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -62,5 +62,6 @@ jobs:
         with:
           commitish: 'main'
           header: ${{ env.RELEASE_BODY }}
+          config-name: github:cpp-linter/.github:/.github/release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- [x] switch to cpp-linter org's release-drafter config
- [x] update permissions for jobs that invoke release-drafter workflows (reusable and local)
- [x] switch labeler workflow to use separate reusable workflow

refs:
- cpp-linter/.github#71
- cpp-linter/.github#74
