### PR TITLE
fix: capture stderr in subprocess output for clang-tidy

### DIFF
--- a/cpp_linter_hooks/clang_tidy.py
+++ b/cpp_linter_hooks/clang_tidy.py
@@ -18,9 +18,11 @@ def run_clang_tidy(args=None) -> Tuple[int, str]:
     retval = 0
     output = ""
     try:
-        sp = subprocess.run(command, stdout=subprocess.PIPE, encoding="utf-8")
+        sp = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
+        )
         retval = sp.returncode
-        output = sp.stdout
+        output = (sp.stdout or "") + (sp.stderr or "")
         if "warning:" in output or "error:" in output:
             retval = 1
         return retval, output


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error capture to include all diagnostic messages from the linter, ensuring comprehensive output is displayed to users instead of missing some warnings and errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->