### PR TITLE
feat: add `_is_version_installed` function and corresponding tests

### DIFF
--- a/cpp_linter_hooks/util.py
+++ b/cpp_linter_hooks/util.py
@@ -59,6 +59,17 @@ def _resolve_version(versions: List[str], user_input: Optional[str]) -> Optional
         return None
 
 
+def _is_version_installed(tool: str, version: str) -> Optional[Path]:
+    """Return the tool path if the installed version matches, otherwise None."""
+    existing = shutil.which(tool)
+    if not existing:
+        return None
+    result = subprocess.run([existing, "--version"], capture_output=True, text=True)
+    if version in result.stdout:
+        return Path(existing)
+    return None
+
+
 def _install_tool(tool: str, version: str) -> Optional[Path]:
     """Install a tool using pip, logging output on failure."""
     result = subprocess.run(
@@ -87,4 +98,6 @@ def resolve_install(tool: str, version: Optional[str]) -> Optional[Path]:
             else DEFAULT_CLANG_TIDY_VERSION
         )
 
-    return _install_tool(tool, user_version)
+    return _is_version_installed(tool, user_version) or _install_tool(
+        tool, user_version
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ import sys
 from cpp_linter_hooks.util import (
     get_version_from_dependency,
     _resolve_version,
+    _is_version_installed,
     _install_tool,
     resolve_install,
     DEFAULT_CLANG_FORMAT_VERSION,
@@ -117,6 +118,51 @@ def test_resolve_version_clang_tidy(user_input, expected):
     assert result == expected
 
 
+# Tests for _is_version_installed
+@pytest.mark.benchmark
+def test_is_version_installed_not_in_path():
+    """Test _is_version_installed when tool is not in PATH."""
+    with patch("shutil.which", return_value=None):
+        result = _is_version_installed("clang-format", "20.1.7")
+        assert result is None
+
+
+@pytest.mark.benchmark
+def test_is_version_installed_version_matches():
+    """Test _is_version_installed when installed version matches."""
+    mock_path = "/usr/bin/clang-format"
+
+    def patched_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args, returncode=0, stdout="clang-format version 20.1.7"
+        )
+
+    with (
+        patch("shutil.which", return_value=mock_path),
+        patch("subprocess.run", side_effect=patched_run),
+    ):
+        result = _is_version_installed("clang-format", "20.1.7")
+        assert result == Path(mock_path)
+
+
+@pytest.mark.benchmark
+def test_is_version_installed_version_mismatch():
+    """Test _is_version_installed when installed version doesn't match."""
+    mock_path = "/usr/bin/clang-format"
+
+    def patched_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args, returncode=0, stdout="clang-format version 22.1.0"
+        )
+
+    with (
+        patch("shutil.which", return_value=mock_path),
+        patch("subprocess.run", side_effect=patched_run),
+    ):
+        result = _is_version_installed("clang-format", "20.1.7")
+        assert result is None
+
+
 # Tests for _install_tool
 @pytest.mark.benchmark
 def test_install_tool_success():
@@ -178,8 +224,14 @@ def test_resolve_install_tool_already_installed_correct_version():
     """Test resolve_install when tool is already installed with correct version."""
     mock_path = "/usr/bin/clang-format"
 
+    def patched_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args, returncode=0, stdout="clang-format version 20.1.7"
+        )
+
     with (
         patch("shutil.which", return_value=mock_path),
+        patch("subprocess.run", side_effect=patched_run),
     ):
         result = resolve_install("clang-format", "20.1.7")
         assert Path(result) == Path(mock_path)
@@ -187,11 +239,17 @@ def test_resolve_install_tool_already_installed_correct_version():
 
 @pytest.mark.benchmark
 def test_resolve_install_tool_version_mismatch():
-    """Test resolve_install when tool has wrong version."""
+    """Test resolve_install when tool has wrong version, triggering reinstall."""
     mock_path = "/usr/bin/clang-format"
+
+    def patched_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args, returncode=0, stdout="clang-format version 22.1.0"
+        )
 
     with (
         patch("shutil.which", return_value=mock_path),
+        patch("subprocess.run", side_effect=patched_run),
         patch(
             "cpp_linter_hooks.util._install_tool", return_value=Path(mock_path)
         ) as mock_install,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Installation workflow now detects and prefers existing matching tool versions, avoiding unnecessary re-installation and speeding setup.

* **Tests**
  * Added tests covering version-detection, matching/mismatched scenarios, and installation verification to ensure correct install/resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->