### PR TITLE
fix: remove unused setuptools dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "pip>=20.3", # Required to install clang-format and clang-tidy
     "tomli>=1.1.0; python_version < '3.11'",
-"clang-format==22.1.0",
+    "clang-format==22.1.0",
     "clang-tidy==22.1.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed version constraint from setuptools dependency in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->