### PR TITLE
docs: add project setup examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ result.txt
 testing/main.c
 */*compile_commands.json
 testing/benchmark_results.txt
-examples/*
 
 # Ignore Python wheel packages (clang-format, clang-tidy)
 clang-tidy-1*
@@ -23,3 +22,6 @@ clang-format-2*
 
 # Ignore CodeSpeed folder
 .codspeed/
+
+# Others
+plan.md

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ comparison.
 - [Troubleshooting](#troubleshooting)
   - [Performance Optimization](#performance-optimization)
   - [Verbose Output](#verbose-output)
+- [Examples](#examples)
 - [FAQ](#faq)
   - [What's the difference between `cpp-linter-hooks` and `mirrors-clang-format`?](#whats-the-difference-between-cpp-linter-hooks-and-mirrors-clang-format)
 - [Contributing](#contributing)
@@ -296,6 +297,14 @@ repos:
       - id: clang-tidy
         args: [--checks=.clang-tidy, --verbose]   # Shows which compile_commands.json is used
 ```
+
+## Examples
+
+Two self-contained templates plus quick snippets for other common setups.
+
+- [CMake minimal config](examples/cmake/) — covers ~80% of C++ projects
+- [Large project `files:` regex](examples/large-project/) — scoping hooks for speed
+- [Quick snippets](examples/README.md) — Meson, clang-format-only, monorepo, CI, `compile_commands.json`
 
 ## FAQ
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,62 @@
+# Examples
+
+- [CMake project](cmake/) — the default for ~80% of C++ projects
+- [Large project `files:` regex](large-project/) — scoping hooks for speed
+
+## Quick snippets
+
+### clang-format only (no build system)
+
+```yaml
+      - id: clang-format
+        args: [--style=file, --version=21]
+        files: \.(cpp|cc|cxx|c|h|hpp)$
+```
+
+### Meson
+
+```bash
+meson setup build    # auto-detect works with build/
+```
+
+Or point explicitly: `args: [--compile-commands=builddir, --checks=.clang-tidy]`.
+
+### clang-tidy + compile_commands.json
+
+```yaml
+      - id: clang-tidy
+        args: [--compile-commands=build, --checks=.clang-tidy, --version=21, --jobs=4]
+        files: ^src/.*\.cpp$
+```
+
+Add `--fix` to auto-apply fixes.  Add `-v` to see which database is used.
+
+### Monorepo
+
+```yaml
+      - id: clang-format
+        name: clang-format (backend)
+        args: [--style=file:backend/.clang-format, --version=21]
+        files: ^backend/.*\.(cpp|hpp)$
+
+      - id: clang-format
+        name: clang-format (frontend)
+        args: [--style=file:frontend/.clang-format, --version=21]
+        files: ^frontend/.*\.(cpp|hpp)$
+```
+
+### CI (GitHub Actions)
+
+```yaml
+# .github/workflows/lint.yml
+name: Lint
+on: [push, pull_request]
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - uses: pre-commit/action@v3.0.1
+```

--- a/examples/cmake/README.md
+++ b/examples/cmake/README.md
@@ -1,0 +1,35 @@
+# CMake Project
+
+If you already have a CMake project, you need **two files**:
+
+## .pre-commit-config.yaml
+
+```yaml
+repos:
+  - repo: https://github.com/cpp-linter/cpp-linter-hooks
+    rev: v1.4.0
+    hooks:
+      - id: clang-format
+        args: [--style=file, --version=21]
+        files: ^(src|include)/.*\.(cpp|cc|cxx|h|hpp)$
+
+      - id: clang-tidy
+        args: [--checks=.clang-tidy, --version=21]
+        files: ^(src|include)/.*\.(cpp|cc|cxx)$
+```
+
+## CMakeLists.txt
+
+Add one line so `clang-tidy` can see your include paths:
+
+```cmake
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+Then `cmake -B build` and `pre-commit install`.  Done.
+
+---
+
+`compile_commands.json` is auto-detected from `build/`, `out/`, `cmake-build-debug/`,
+or `_build/`.  If your build dir has a different name, pass it explicitly:
+`args: [--compile-commands=mybuild, ...]`.

--- a/examples/large-project/README.md
+++ b/examples/large-project/README.md
@@ -1,0 +1,38 @@
+# Large Project — `files:` Regex
+
+Use `files:` to limit hooks to relevant directories.  This is the #1 perf lever.
+
+## One-size-fits-most
+
+```yaml
+      - id: clang-format
+        files: ^(src|include)/.*\.(cpp|cc|cxx|h|hpp)$
+```
+
+## Common patterns
+
+```yaml
+# Exclude generated code
+files: ^src/(?!generated/|proto/).*\.(cpp|hpp)$
+
+# Library (public headers + private src)
+files: ^(include|src)/.*\.(cpp|cc|cxx|h|hpp|hxx)$
+
+# Application (no public headers)
+files: ^src/.*\.(cpp|cc|cxx|h|hpp)$
+
+# Qt (skip moc_)
+files: ^src/(?!moc_|ui_).*\.(cpp|h)$
+
+# CUDA
+files: ^src/.*\.(cpp|cc|cxx|cu|cuh|h|hpp)$
+
+# Embedded / bare-metal C
+files: \.(c|h|s|S)$
+```
+
+## Perf tips
+
+- **Don't lint headers directly with `clang-tidy`** — they're processed when a `.cpp` includes them.  Restrict to `files: ^src/.*\.cpp$`.
+- **Use `--jobs=N` for `clang-tidy`** — start with `N=2`, go up to CPU core count.
+- **`--dry-run` for `clang-format` in CI** — fail with a readable diff instead of auto-committing formatting.


### PR DESCRIPTION
## Summary

Add `examples/` with real-world project templates to help users get started faster.

### What's included

- **`examples/cmake/`** — CMake minimal config with `compile_commands.json` auto-detect (covers ~80% of C++ projects)
- **`examples/large-project/`** — `files:` regex reference: patterns, exclusions, perf tips
- **`examples/README.md`** — Quick snippets for Meson, monorepo, clang-format-only, CI, compile_commands.json
- Link to examples from main README

### Design choices

- Kept it to **2 standalone templates** (cmake + large-project) — the rest are short code blocks in the index to minimize maintenance burden
- All examples are README-only, zero executable code to rot
- Removed obsolete `examples/*` from `gitignore`

### Files changed

| File | Change |
|------|--------|
| `.gitignore` | Remove `examples/*` |
| `README.md` | Add Examples section with links |
| `examples/README.md` | Index + quick snippets (new) |
| `examples/cmake/README.md` | CMake template (new) |
| `examples/large-project/README.md` | `files:` regex reference (new) |