### PR TITLE
feat: add Windows and macOS to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
     steps:
       - name: Checkout
@@ -34,7 +36,7 @@ jobs:
           uv run coverage report
           uv run coverage xml
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 #v5
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
## Summary

Adds `windows-latest` and `macos-latest` to the CI test matrix alongside the existing `ubuntu-latest`.

## Changes

- **`.github/workflows/test.yml`**: 
  - Added `os` dimension to the test matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`)
  - Set `runs-on` to `${{ matrix.os }}` (was hardcoded to `ubuntu-latest`)
  - Set `fail-fast: false` so one OS failure doesn't cancel others
  - Updated codecov upload condition to only run on `ubuntu-latest` (was: on any OS with Python 3.13)

## Reasoning

- The project classifiers claim support for Windows, macOS, and Linux — CI should validate each
- Pre-commit hooks need to work reliably on all major platforms
- Bash is available on all GitHub runners, so `testing/run.sh` works cross-platform
- Pytest `tmp_path` and `uv` are fully cross-platform

Closes #TBD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to run across Ubuntu, Windows, and macOS platforms, ensuring broader compatibility and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cpp-linter/cpp-linter-hooks/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->