### PR TITLE
docs: add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for your interest in contributing to `cpp-linter-hooks`!
+
+## Setup
+
+You'll need Python 3.10+ and [uv](https://docs.astral.sh/uv/).
+
+```bash
+git clone https://github.com/cpp-linter/cpp-linter-hooks.git
+cd cpp-linter-hooks
+uv sync
+source .venv/bin/activate
+pre-commit install
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# With coverage
+coverage run -m pytest && coverage report
+```
+
+## Code Style
+
+We use [ruff](https://docs.astral.sh/ruff/) for linting and formatting. The
+pre-commit hooks installed above will check your code automatically on commit.
+You can also run them manually:
+
+```bash
+pre-commit run --all-files
+```
+
+## Making Changes
+
+1. Create a branch from `main`
+2. Make your changes and add tests
+3. Run `pytest` to make sure everything passes
+4. Open a pull request against `main`
+
+PRs should have a clear description of what changed and why. Reference any
+related issues.
+
+## Release Process
+
+Releases are tagged by maintainers. Versioning follows
+[setuptools-scm](https://github.com/pypa/setuptools-scm) — the version is
+derived from git tags automatically.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not** open a public
+issue. Instead, report it privately via
+[GitHub's private vulnerability reporting](https://github.com/cpp-linter/cpp-linter-hooks/security/advisories/new).
+
+We'll respond as quickly as possible and keep you updated throughout the
+process.
+
+## Supported Versions
+
+Only the latest release receives security patches.


### PR DESCRIPTION
Add missing community health files required for opensoruce compliance.

- **CONTRIBUTING.md** — Setup instructions, test commands, code style, and PR process
- **SECURITY.md** — Private vulnerability reporting policy and supported versions

Both files are kept intentionally short and focused.