### PR TITLE
docs: add cross-reference to cpp-linter-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,16 @@ this project also provides `clang-tidy`, compile database discovery, explicit
 tool-version selection, and richer diagnostics. See the [FAQ](#faq) for the full
 comparison.
 
+> [!TIP]
+> Using GitHub Actions for CI? Check out
+> **[cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action)** —
+> our companion GitHub Action that runs the same tools in CI with rich PR reviews,
+> thread comments, step summaries, and file annotations.
+
 ## Table of Contents
 
 - [Why cpp-linter-hooks?](#why-cpp-linter-hooks)
+- [GitHub Actions? Try cpp-linter-action](#github-actions-try-cpp-linter-action)
 - [Requirements](#requirements)
 - [Quick Start](#quick-start)
   - [Custom Configuration Files](#custom-configuration-files)


### PR DESCRIPTION
Add a TIP callout in the README recommending [cpp-linter-action](https://github.com/cpp-linter/cpp-linter-action) for users who want GitHub Actions CI integration, with bidirectional cross-linking between the two projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with information about the cpp-linter-action companion project, including a new Table of Contents entry to help users discover the related GitHub Actions integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->