### PR TITLE
docs: add back-navigation and standardize Used By

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Test](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml)
 [![CodeQL](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml)
 
+> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+
 A pre-commit hook repository for C/C++ projects that installs and runs
 `clang-format` and `clang-tidy` through the
 [pre-commit](https://pre-commit.com/) framework.
@@ -321,6 +323,8 @@ Two self-contained templates plus quick snippets for other common setups.
 ![computationalgeography](https://github.com/computationalgeography.png?size=20) computationalgeography&nbsp;&nbsp;
 ![IMSY-DKFZ](https://github.com/IMSY-DKFZ.png?size=20) IMSY-DKFZ and
 [many more](https://github.com/search?q=repo%3A%20https%3A%2F%2Fgithub.com%2Fcpp-linter%2Fcpp-linter-hooks&type=code).
+
+See the [cpp-linter hub](https://cpp-linter.github.io/) for the full list of organizations using cpp-linter tools.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml)
 [![CodeQL](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml)
 
-> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 A pre-commit hook repository for C/C++ projects that installs and runs
 `clang-format` and `clang-tidy` through the

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![codecov](https://codecov.io/gh/cpp-linter/cpp-linter-hooks/branch/main/graph/badge.svg?token=L74Z3HZ4Y5)](https://codecov.io/gh/cpp-linter/cpp-linter-hooks)
 [![Test](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/test.yml)
 [![CodeQL](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-hooks/actions/workflows/codeql.yml)
-
-> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 A pre-commit hook repository for C/C++ projects that installs and runs
 `clang-format` and `clang-tidy` through the


### PR DESCRIPTION
Adds back-navigation link to the cpp-linter hub and links the Used By section to the comprehensive hub list.