### PR TITLE
chore: update README to v1.6.0 and remove outdated Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ comparison.
 
 - [Why cpp-linter-hooks?](#why-cpp-linter-hooks)
 - [GitHub Actions? Try cpp-linter-action](#github-actions-try-cpp-linter-action)
-- [Requirements](#requirements)
 - [Quick Start](#quick-start)
   - [Custom Configuration Files](#custom-configuration-files)
   - [Custom Clang Tool Version](#custom-clang-tool-version)
@@ -58,10 +57,6 @@ comparison.
 - [Contributing](#contributing)
 - [License](#license)
 
-## Requirements
-
-`cpp-linter-hooks` v1.5.0 and later requires Python 3.10 or newer.
-
 ## Quick Start
 
 Add this configuration to your `.pre-commit-config.yaml` file:
@@ -69,7 +64,7 @@ Add this configuration to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0  # Use the tag or commit you want
+    rev: v1.6.0  # Use the tag or commit you want
     hooks:
       - id: clang-format
         args: [--style=Google] # Other coding style: LLVM, GNU, Chromium, Microsoft, Mozilla, WebKit.
@@ -84,7 +79,7 @@ To use custom configurations like `.clang-format` and `.clang-tidy`:
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: clang-format
         args: [--style=file]  # Loads style from .clang-format file
@@ -93,7 +88,7 @@ repos:
 ```
 
 > [!TIP]
-> The `rev` tag (e.g. `v1.5.0`) is the **project** version, not the clang tool version. Each release bundles a default version of `clang-format` and `clang-tidy` — check the [release notes](https://github.com/cpp-linter/cpp-linter-hooks/releases) to see which tool version a given `rev` ships with. To pin an exact tool version independently of the project release, use `--version` as shown below.
+> The `rev` tag (e.g. `v1.6.0`) is the **project** version, not the clang tool version. Each release bundles a default version of `clang-format` and `clang-tidy` — check the [release notes](https://github.com/cpp-linter/cpp-linter-hooks/releases) to see which tool version a given `rev` ships with. To pin an exact tool version independently of the project release, use `--version` as shown below.
 
 ### Custom Clang Tool Version
 
@@ -102,7 +97,7 @@ To use specific versions of clang-format and clang-tidy (using Python wheel pack
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: clang-format
         args: [--style=file, --version=21] # Specifies version
@@ -126,7 +121,7 @@ automatically — no configuration needed for most projects:
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: clang-tidy
         args: [--checks=.clang-tidy]
@@ -241,7 +236,7 @@ Use -header-filter=.* to display errors from all non-system headers. Use -system
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0  # includes --fix support
+    rev: v1.6.0  # includes --fix support
     hooks:
       - id: clang-tidy
         args: [--checks=.clang-tidy, --fix]
@@ -260,7 +255,7 @@ repos:
 
 ```yaml
 - repo: https://github.com/cpp-linter/cpp-linter-hooks
-  rev: v1.5.0
+  rev: v1.6.0
   hooks:
     - id: clang-format
       args: [--style=file, --version=21]
@@ -275,7 +270,7 @@ or `-j`:
 
 ```yaml
 - repo: https://github.com/cpp-linter/cpp-linter-hooks
-  rev: v1.5.0
+  rev: v1.6.0
   hooks:
     - id: clang-tidy
       args: [--checks=.clang-tidy, --version=21, --jobs=4]
@@ -304,7 +299,7 @@ This approach ensures that only modified files are checked, further speeding up 
 ```yaml
 repos:
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: clang-format
         args: [--style=file, --version=21, --verbose]   # Shows processed files


### PR DESCRIPTION
## Summary

- **Removed** the `## Requirements` section that stated `v1.5.0 and later requires Python 3.10 or newer` — this is outdated since v1.5.0 is no longer current and the minimum Python requirement (3.10) is already defined in `pyproject.toml`.
- **Updated** all `rev: v1.5.0` references in example `.pre-commit-config.yaml` snippets to `rev: v1.6.0`.

## Changes

| File | Change |
|------|--------|
| `README.md` | 9 insertions, 14 deletions — removed Requirements section, bumped all version refs to v1.6.0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README examples to reference `cpp-linter-hooks` v1.6.0 throughout.
  * Refreshed related setup guidance, including `clang-tidy --fix` support and version references in configuration examples.
  * Removed the “Requirements” entry from the table of contents to match the updated document structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->