### PR TITLE
chore: Fixup of #231 to drop python 3.9 from test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Fixup #231



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test coverage to run on Python 3.10 through 3.14.
  * Removed Python 3.9 from the test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->