### PR TITLE
test: cover clang-format main entry point

### DIFF
--- a/cpp_linter_hooks/clang_format.py
+++ b/cpp_linter_hooks/clang_format.py
@@ -68,12 +68,12 @@ def _print_verbose_info(command: list, retval: int, output: str) -> None:
 
 def main() -> int:
     """Run clang-format as a command-line entry point."""
-    retval, output = run_clang_format()  # pragma: no cover
+    retval, output = run_clang_format()
 
-    if retval != 0 and output.strip():  # pragma: no cover
+    if retval != 0 and output.strip():
         print(output)
 
-    return retval  # pragma: no cover
+    return retval
 
 
 if __name__ == "__main__":

--- a/tests/test_clang_format.py
+++ b/tests/test_clang_format.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cpp_linter_hooks.clang_format import run_clang_format
+from cpp_linter_hooks.clang_format import main, run_clang_format
 
 
 @pytest.mark.benchmark
@@ -138,3 +138,22 @@ def test_run_clang_format_verbose_passes_version_diagnostics():
 
     assert (ret, output) == (0, "")
     mock_resolve.assert_called_once_with("clang-format", "21", True)
+
+
+def test_main_returns_success_without_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cpp_linter_hooks.clang_format.run_clang_format", lambda: (0, "")
+    )
+
+    assert main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_prints_failure_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cpp_linter_hooks.clang_format.run_clang_format",
+        lambda: (1, "formatting failed"),
+    )
+
+    assert main() == 1
+    assert capsys.readouterr().out == "formatting failed\n"


### PR DESCRIPTION
## Summary

- cover the successful `clang_format.main()` path
- cover failure output and the non-zero return path
- remove the now-unnecessary coverage exclusions

## Tests

```
uv run pytest tests/test_clang_format.py -q
```

22 tests passed.

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved formatter execution and output behavior while improving coverage tracking for the command-line entry point.
  * The formatter now reliably reports its status and only displays failure output when available.

* **Tests**
  * Added coverage for formatter status handling and conditional failure output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->