### PR TITLE
docs: add missing CLI help text

### DIFF
--- a/cpp_linter_hooks/clang_format.py
+++ b/cpp_linter_hooks/clang_format.py
@@ -7,7 +7,14 @@ from argparse import ArgumentParser
 from cpp_linter_hooks.util import resolve_install_with_diagnostics
 
 parser = ArgumentParser()
-parser.add_argument("--version", default=None)
+parser.add_argument(
+    "--version",
+    default=None,
+    help=(
+        "Version of clang-format to install and run; defaults to the latest "
+        "stable wheel on PyPI"
+    ),
+)
 parser.add_argument(
     "-v", "--verbose", action="store_true", help="Enable verbose output"
 )

--- a/cpp_linter_hooks/clang_tidy.py
+++ b/cpp_linter_hooks/clang_tidy.py
@@ -52,13 +52,36 @@ def _positive_int(value: str) -> int:
 
 
 parser = ArgumentParser()
-parser.add_argument("--version", default=None)
-parser.add_argument("--compile-commands", default=None, dest="compile_commands")
 parser.add_argument(
-    "--no-compile-commands", action="store_true", dest="no_compile_commands"
+    "--version",
+    default=None,
+    help=(
+        "Version of clang-tidy to install and run; defaults to the latest stable "
+        "wheel on PyPI"
+    ),
 )
-parser.add_argument("-j", "--jobs", type=_positive_int, default=1)
-parser.add_argument("-v", "--verbose", action="store_true")
+parser.add_argument(
+    "--compile-commands",
+    default=None,
+    dest="compile_commands",
+    help="Directory containing compile_commands.json to pass to clang-tidy via -p",
+)
+parser.add_argument(
+    "--no-compile-commands",
+    action="store_true",
+    dest="no_compile_commands",
+    help="Disable automatic compile_commands.json detection",
+)
+parser.add_argument(
+    "-j",
+    "--jobs",
+    type=_positive_int,
+    default=1,
+    help="Number of clang-tidy processes to run in parallel (default: 1)",
+)
+parser.add_argument(
+    "-v", "--verbose", action="store_true", help="Enable verbose output"
+)
 parser.add_argument("--fix", action="store_true", help="Apply fixes in place (-fix)")
 
 

--- a/tests/test_clang_format.py
+++ b/tests/test_clang_format.py
@@ -3,7 +3,17 @@ from unittest.mock import patch
 
 import pytest
 
-from cpp_linter_hooks.clang_format import main, run_clang_format
+from cpp_linter_hooks.clang_format import main, parser, run_clang_format
+
+
+def test_all_arguments_have_help():
+    missing_help = [
+        action.option_strings for action in parser._actions if not action.help
+    ]
+    assert missing_help == []
+
+    help_text = " ".join(parser.format_help().split())
+    assert all(" ".join(action.help.split()) in help_text for action in parser._actions)
 
 
 @pytest.mark.benchmark

--- a/tests/test_clang_tidy.py
+++ b/tests/test_clang_tidy.py
@@ -5,7 +5,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cpp_linter_hooks.clang_tidy import _exec_clang_tidy, run_clang_tidy
+from cpp_linter_hooks.clang_tidy import _exec_clang_tidy, parser, run_clang_tidy
+
+
+def test_all_arguments_have_help():
+    missing_help = [
+        action.option_strings for action in parser._actions if not action.help
+    ]
+    assert missing_help == []
+
+    help_text = " ".join(parser.format_help().split())
+    assert all(" ".join(action.help.split()) in help_text for action in parser._actions)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Summary

- add descriptions for every hook-specific CLI argument
- add regression tests that require each parser action to render help text

## Related Issues

Closes #264

## Tests

- `uv run pytest -q` (119 passed)
- `uv run coverage run --source=tests,cpp_linter_hooks -m pytest -q && uv run coverage report` (119 passed; 98% total coverage)
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved command-line help for clang-format and clang-tidy options.
  * Clarified the clang-format version option, including its default behavior.
  * Added descriptions for compilation database, parallel jobs, verbosity, and related options.

* **Tests**
  * Added coverage to verify that all command-line options include and display help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->